### PR TITLE
Add switch case to indentation rule

### DIFF
--- a/lib/configs/base.js
+++ b/lib/configs/base.js
@@ -143,7 +143,7 @@ function base() {
             "guard-for-in": 0, // http://eslint.org/docs/rules/guard-for-in
             "handle-callback-err": [2, "^(err|error)$"], // http://eslint.org/docs/rules/handle-callback-err
             "id-length": 0, // http://eslint.org/docs/rules/id-length
-            "indent": [2, 4], // http://eslint.org/docs/rules/indent
+            "indent": [2, 4, {"SwitchCase": 1}], // http://eslint.org/docs/rules/indent
             "init-declarations": 0, // http://eslint.org/docs/rules/init-declarations
             "jsx-quotes": [2, "prefer-double"], // http://eslint.org/docs/rules/jsx-quotes
             "key-spacing": [2, { "beforeColon": false, "afterColon": true }], // http://eslint.org/docs/rules/key-spacing


### PR DESCRIPTION
This prevents eslint errors when having a switch statement with indented case statements.