### PR TITLE
bumped eslint version to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/peerigon/eslint-config-peerigon#readme",
   "peerDependencies": {
-    "eslint": "^2.0.0",
+    "eslint": "^3.0.0",
     "eslint-plugin-jsdoc": "^2.3.1"
   }
 }


### PR DESCRIPTION
Seems to be safe:
http://eslint.org/docs/user-guide/migrating-to-3.0.0