### PR TITLE
feat: Switch back to eslint default parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provided configs
 ### [`peerigon`](base.js)
 
 **Base rules for every project. You should always add these rules.**
-**Requires [babel-eslint](https://github.com/babel/babel-eslint), [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) and [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) as peer dependency in npm@2 environments (usually node 4).**
+**Requires [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) and [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) as installed project dependency in npm@2 environments (usually node 4).**
 
 These rules assume a modern project with full ES2015 support and a module system with a node.js-like resolving behavior (like node.js and webpack). For special rules, which extend these base rules for older environments, see below.
 
@@ -87,7 +87,7 @@ want to transpile your code with babel:
 
 ### [`peerigon/react`](react.js)
 
-**Requires [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react) as peer dependency.**
+**Requires [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react) to be installed as project dependency.**
 
 Additional rules for [React](https://facebook.github.io/react/) development.
 Can also be used in other JSX environments, like [Preact](https://github.com/developit/preact):
@@ -104,7 +104,7 @@ Can also be used in other JSX environments, like [Preact](https://github.com/dev
 
 ### [`peerigon/flowtype`](flowtype.js)
 
-**Requires [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype) as peer dependency.**
+**Requires [`babel-eslint`](https://github.com/babel/babel-eslint) and [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype) to be installed as project dependency.**
 
 Additional rules for [Flowtype](https://flowtype.org/).
 

--- a/base.js
+++ b/base.js
@@ -2,12 +2,10 @@
 /* eslint-disable sort-keys */
 
 module.exports = {
-    parser: "babel-eslint",
     env: {
         es6: true
     },
     parserOptions: {
-        ecmaVersion: 6,
         sourceType: "module",
         ecmaFeatures: {
             experimentalObjectRestSpread: true

--- a/flowtype.js
+++ b/flowtype.js
@@ -2,17 +2,13 @@
 /* eslint-disable sort-keys */
 
 module.exports = {
+    parser: "babel-eslint",
     plugins: [
         "flowtype"
     ],
     extends: [
         "plugin:flowtype/recommended"
     ],
-    parserOptions: {
-        ecmaFeatures: {
-            flow: true
-        }
-    },
     settings: {
         flowtype: {
             onlyFilesWithFlowAnnotation: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,493 +1,44 @@
 {
   "name": "eslint-config-peerigon",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "JSONStream": {
-      "version": "http://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "http://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-      }
-    },
-    "align-text": {
-      "version": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "http://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-        "longest": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-        "repeat-string": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-      }
-    },
-    "amdefine": {
-      "version": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
-    "array-find-index": {
-      "version": "http://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
-    },
-    "array-ify": {
-      "version": "http://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-      "dev": true
-    },
-    "async": {
-      "version": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
-      "integrity": "sha512-/xr1ADm5bnTjjN+xwoXb7lF4v2rnxMzNZzFU7h8SxB+qB6+IqSTOOqVcpaPTUC2Non/MbQxS3OIZnJpQ2X21aQ==",
-      "requires": {
-        "chalk": "2.3.0",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "supports-color": "4.5.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
-    },
-    "babel-eslint": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.1.tgz",
-      "integrity": "sha512-h3moF6PCTQE06UjMMG+ydZSBvZ4Q7rqPE/5WAUOvUyHYUTqxm8JVhjZRiG1avI/tGVOK4BnZLDQapyLzh8DeKg==",
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.0",
-        "babel-traverse": "7.0.0-beta.0",
-        "babel-types": "7.0.0-beta.0",
-        "babylon": "7.0.0-beta.22"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz",
-      "integrity": "sha512-DaQccFBBWBEzMdqbKmNXamY0m1yLHJGOdbbEsNoGdJrrU7wAF3wwowtDDPzF0ZT3SqJXPgZW/P2kgBX9moMuAA==",
-      "requires": {
-        "babel-helper-get-function-arity": "7.0.0-beta.0",
-        "babel-template": "7.0.0-beta.0",
-        "babel-traverse": "7.0.0-beta.0",
-        "babel-types": "7.0.0-beta.0"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz",
-      "integrity": "sha512-csqAic15/2Vm1951nJxkkL9K8E6ojyNF/eAOjk7pqJlO8kvgrccGNFCV9eDwcGHDPe5AjvJGwVSAcQ5fit9wuA==",
-      "requires": {
-        "babel-types": "7.0.0-beta.0"
-      }
-    },
-    "babel-messages": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-beta.0.tgz",
-      "integrity": "sha512-eXdShsm9ZTh9AQhlIaAn6HR3xWpxCnK9ZwIDA9QyjnwTgMctGxHHflw4b4RJ3/ZjTL0Vrmvm0tQXPkp49mTAUw=="
-    },
-    "babel-template": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.0.tgz",
-      "integrity": "sha512-tmdH+MmmU0F6Ur8humpevSmFzYKbrN3Oru0g5Qyg4R6+sxjnzZmnvzUbsP0aKMr7tB0Ua6xhEb9arKTOsEMkyA==",
-      "requires": {
-        "babel-traverse": "7.0.0-beta.0",
-        "babel-types": "7.0.0-beta.0",
-        "babylon": "7.0.0-beta.22",
-        "lodash": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-      }
-    },
-    "babel-traverse": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
-      "integrity": "sha512-IKzuTqUcQtMRZ0Vv5RjIrGGj33eBKmNTNeRexWSyjPPuAciyNkva1rt7WXPfHfkb+dX7coRAIUhzeTUEzhnwdA==",
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.0",
-        "babel-helper-function-name": "7.0.0-beta.0",
-        "babel-messages": "7.0.0-beta.0",
-        "babel-types": "7.0.0-beta.0",
-        "babylon": "7.0.0-beta.22",
-        "debug": "3.1.0",
-        "globals": "10.1.0",
-        "invariant": "2.2.2",
-        "lodash": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-      }
-    },
-    "babel-types": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
-      "integrity": "sha512-rJc2kV9iPJGLlqIY71AM3nPcdkoeLRCDuR07GFgfd3lFl4TsBQq76TxYQQIZ2MONg1HpsqmuoCXr9aZ1Oa4wYw==",
-      "requires": {
-        "esutils": "2.0.2",
-        "lodash": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "to-fast-properties": "2.0.0"
-      }
-    },
-    "babylon": {
-      "version": "7.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz",
-      "integrity": "sha512-Yl7iT8QGrS8OfR7p6R12AJexQm+brKwrryai4VWZ7NHUbPoZ5al3+klhvl/14shXZiLa7uK//OIFuZ1/RKHgoA=="
-    },
-    "buffer-shims": {
-      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
     "builtin-modules": {
-      "version": "http://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "camelcase": {
-      "version": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-      "dev": true
-    },
-    "camelcase-keys": {
-      "version": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
-      "requires": {
-        "camelcase": "http://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-        "map-obj": "http://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "http://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        }
-      }
-    },
-    "center-align": {
-      "version": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-        "lazy-cache": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-      }
-    },
-    "chalk": {
-      "version": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-        "escape-string-regexp": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "has-ansi": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-        "strip-ansi": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "supports-color": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-      }
-    },
-    "cliui": {
-      "version": "http://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true,
-      "requires": {
-        "string-width": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "strip-ansi": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "wrap-ansi": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
-      }
-    },
-    "code-point-at": {
-      "version": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
-    },
-    "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "comment-parser": {
-      "version": "http://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
-      "integrity": "sha1-snSjySS2suVXaPcSrNPjADy1X1c=",
-      "requires": {
-        "readable-stream": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz"
-      }
-    },
-    "compare-func": {
-      "version": "http://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-      "dev": true,
-      "requires": {
-        "array-ify": "http://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-        "dot-prop": "http://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz"
-      }
-    },
-    "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "readable-stream": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-      }
-    },
-    "conventional-changelog": {
-      "version": "http://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.3.tgz",
-      "integrity": "sha1-JigweKw4wJTfKvFgSwpGu8AWXE0=",
-      "dev": true,
-      "requires": {
-        "conventional-changelog-angular": "http://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.3.tgz",
-        "conventional-changelog-atom": "http://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
-        "conventional-changelog-codemirror": "http://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
-        "conventional-changelog-core": "http://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.8.0.tgz",
-        "conventional-changelog-ember": "http://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.5.tgz",
-        "conventional-changelog-eslint": "http://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
-        "conventional-changelog-express": "http://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
-        "conventional-changelog-jquery": "http://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-        "conventional-changelog-jscs": "http://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-        "conventional-changelog-jshint": "http://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz"
-      }
-    },
-    "conventional-changelog-angular": {
-      "version": "http://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.3.tgz",
-      "integrity": "sha1-586AeoXdR1DhtBf3ZgRUl1EeByY=",
-      "dev": true,
-      "requires": {
-        "compare-func": "http://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-        "github-url-from-git": "http://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-atom": {
-      "version": "http://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
-      "integrity": "sha1-Z6R8ZqQrL4kJ7xWHyZia4d5zC5I=",
-      "dev": true,
-      "requires": {
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-codemirror": {
-      "version": "http://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
-      "integrity": "sha1-dXelkdv5tTjnoVCn7mL2WihyszQ=",
-      "dev": true,
-      "requires": {
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-core": {
-      "version": "http://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.8.0.tgz",
-      "integrity": "sha1-l3hItBbK8V+wnyCxKmLUDvFFuVc=",
-      "dev": true,
-      "requires": {
-        "conventional-changelog-writer": "http://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
-        "conventional-commits-parser": "http://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-        "dateformat": "http://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-        "get-pkg-repo": "http://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
-        "git-raw-commits": "http://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-        "git-remote-origin-url": "http://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-        "git-semver-tags": "http://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-        "lodash": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "normalize-package-data": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz",
-        "read-pkg": "http://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-        "read-pkg-up": "http://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "through2": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-      }
-    },
-    "conventional-changelog-ember": {
-      "version": "http://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.5.tgz",
-      "integrity": "sha1-ziHVz4PNXr4F0j/fIy2IRPS1ak8=",
-      "dev": true,
-      "requires": {
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-eslint": {
-      "version": "http://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
-      "integrity": "sha1-pSQR6ZngUBzlALhWsKZD0DMJB+I=",
-      "dev": true,
-      "requires": {
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-express": {
-      "version": "http://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
-      "integrity": "sha1-VcbIQcgRliA2wDe9vZZKVK4xD84=",
-      "dev": true,
-      "requires": {
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-jquery": {
-      "version": "http://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-      "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-      "dev": true,
-      "requires": {
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-jscs": {
-      "version": "http://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-      "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-      "dev": true,
-      "requires": {
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-jshint": {
-      "version": "http://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz",
-      "integrity": "sha1-AMq46aMxdIer2UxNhGcTQpGNKgc=",
-      "dev": true,
-      "requires": {
-        "compare-func": "http://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-        "q": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-      }
-    },
-    "conventional-changelog-writer": {
-      "version": "http://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
-      "integrity": "sha1-P0y00APrtWmJ0w00WJO1KkNjnI4=",
-      "dev": true,
-      "requires": {
-        "compare-func": "http://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-        "conventional-commits-filter": "http://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-        "dateformat": "http://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-        "handlebars": "http://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "lodash": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "meow": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "semver": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "split": "http://registry.npmjs.org/split/-/split-1.0.0.tgz",
-        "through2": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-      }
-    },
-    "conventional-commits-filter": {
-      "version": "http://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-      "integrity": "sha1-b8KmWTcrw/IznPn//34bA0S5MDk=",
-      "dev": true,
-      "requires": {
-        "is-subset": "http://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-        "modify-values": "http://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz"
-      }
-    },
-    "conventional-commits-parser": {
-      "version": "http://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-      "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
-      "dev": true,
-      "requires": {
-        "JSONStream": "http://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-        "is-text-path": "http://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-        "lodash": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "meow": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "split2": "http://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-        "through2": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-        "trim-off-newlines": "http://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz"
-      }
-    },
-    "conventional-recommended-bump": {
-      "version": "http://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-0.3.0.tgz",
-      "integrity": "sha1-6Dnej1fLtDRFyLSWdAHeBkTEJdg=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-        "conventional-commits-filter": "http://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-        "conventional-commits-parser": "http://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-        "git-latest-semver-tag": "http://registry.npmjs.org/git-latest-semver-tag/-/git-latest-semver-tag-1.0.2.tgz",
-        "git-raw-commits": "http://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-        "meow": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-      }
     },
     "core-util-is": {
       "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "currently-unhandled": {
-      "version": "http://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "array-find-index": "http://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
-      }
-    },
-    "dargs": {
-      "version": "http://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-      "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-      }
-    },
-    "dateformat": {
-      "version": "http://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-        "meow": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
-      }
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "decamelize": {
-      "version": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
-    "dot-prop": {
-      "version": "http://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true,
-      "requires": {
-        "is-obj": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        }
       }
     },
     "error-ex": {
@@ -495,24 +46,318 @@
       "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
       "dev": true,
       "requires": {
-        "is-arrayish": "http://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+        "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
       }
     },
-    "escape-string-regexp": {
-      "version": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
     "eslint-find-rules": {
-      "version": "http://registry.npmjs.org/eslint-find-rules/-/eslint-find-rules-1.14.3.tgz",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-find-rules/-/eslint-find-rules-1.14.3.tgz",
       "integrity": "sha1-Uf+BafC/qs81de3YxDmpTZGc2to=",
       "dev": true,
       "requires": {
-        "cliui": "http://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-        "eslint-rule-documentation": "http://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.6.tgz",
-        "path-is-absolute": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-        "which": "http://registry.npmjs.org/which/-/which-1.2.12.tgz",
-        "window-size": "http://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-        "yargs": "http://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz"
+        "cliui": "3.2.0",
+        "eslint-rule-documentation": "1.0.18",
+        "path-is-absolute": "1.0.0",
+        "which": "1.3.0",
+        "window-size": "0.2.0",
+        "yargs": "5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "eslint-rule-documentation": {
+          "version": "1.0.18",
+          "resolved": "https://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.18.tgz",
+          "integrity": "sha512-MaxcBW2X4IF7Bp8aTOgvYYHETb8k3VlJhmG1y+tBDbX/tmC3H6s4DsEndn0LMvBSfh+TGz/6e5om+HpfO7Oa6A==",
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
+          "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "3.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
+          "integrity": "sha1-UIE1XRnZ0MjF2BrakIy05tGGZk8=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {
@@ -778,454 +623,195 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "http://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.0.0.tgz",
-      "integrity": "sha1-YGO08cmAGtNamnDs51sMmASh5Ek=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.2.0.tgz",
+      "integrity": "sha512-Jx/PoZ8VLOnS2BYwoVeCqXch+ApyQyc7bAImka7zlVRDrob054l4Do+QLppa1WpNV+ftYZGYVPCLjpKCe4VI3A==",
       "requires": {
-        "comment-parser": "http://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
-        "lodash": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        "comment-parser": "0.4.2",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      },
+      "dependencies": {
+        "comment-parser": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
+          "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+          "requires": {
+            "readable-stream": "2.3.3"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
     },
-    "eslint-rule-documentation": {
-      "version": "http://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.6.tgz",
-      "integrity": "sha1-iTGecSmJ6LfIrGU6O6i+myKdHmg=",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-    },
-    "figures": {
-      "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true
+        }
       }
     },
     "find-up": {
-      "version": "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-        "pinkie-promise": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
       }
     },
-    "fs-access": {
-      "version": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-      "dev": true,
-      "requires": {
-        "null-check": "http://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz"
-      }
-    },
-    "get-caller-file": {
-      "version": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
-    },
-    "get-pkg-repo": {
-      "version": "http://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
-      "integrity": "sha1-Q8a0wEi3XdYE/FOI7ezeVX9jNd8=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz",
-        "meow": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "normalize-package-data": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-        "parse-github-repo-url": "http://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
-        "through2": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-      }
-    },
-    "get-stdin": {
-      "version": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
-    },
-    "git-latest-semver-tag": {
-      "version": "http://registry.npmjs.org/git-latest-semver-tag/-/git-latest-semver-tag-1.0.2.tgz",
-      "integrity": "sha1-BhEwy/QnQRHMa+RhKz/zptk+JmA=",
-      "dev": true,
-      "requires": {
-        "git-semver-tags": "http://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-        "meow": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
-      }
-    },
-    "git-raw-commits": {
-      "version": "http://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-      "integrity": "sha1-DzqL/ZmuDy2LkiTViJKXXppS0Dw=",
-      "dev": true,
-      "requires": {
-        "dargs": "http://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-        "lodash.template": "http://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-        "meow": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "split2": "http://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-        "through2": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-      }
-    },
-    "git-remote-origin-url": {
-      "version": "http://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-      "dev": true,
-      "requires": {
-        "gitconfiglocal": "http://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-        "pify": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-      }
-    },
-    "git-semver-tags": {
-      "version": "http://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-      "integrity": "sha1-sx/QLIq1eL1sm1ysyl4cZMEXesE=",
-      "dev": true,
-      "requires": {
-        "meow": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "semver": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-      }
-    },
-    "gitconfiglocal": {
-      "version": "http://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-      "dev": true,
-      "requires": {
-        "ini": "http://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-      }
-    },
-    "github-url-from-git": {
-      "version": "http://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-      "dev": true
-    },
-    "globals": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-10.1.0.tgz",
-      "integrity": "sha1-RCWhiBvg0za0qCOoKnvnJdXdmHw="
     },
     "graceful-fs": {
-      "version": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
-    },
-    "handlebars": {
-      "version": "http://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-      "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
-      "dev": true,
-      "requires": {
-        "async": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "optimist": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-        "source-map": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-        "uglify-js": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.8.20.tgz"
-      }
-    },
-    "has-ansi": {
-      "version": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-      }
-    },
-    "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-    },
-    "hosted-git-info": {
-      "version": "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz",
-      "integrity": "sha1-eg0JeGPYhsD6u9zTe/F1jYvs+KU=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "http://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
-      "requires": {
-        "repeating": "http://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-      }
     },
     "inherits": {
       "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "ini": {
-      "version": "http://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-      "dev": true
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "invert-kv": {
-      "version": "http://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
-    },
     "is-arrayish": {
-      "version": "http://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-buffer": {
-      "version": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
-    },
     "is-builtin-module": {
-      "version": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "http://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
       }
     },
-    "is-finite": {
-      "version": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-      }
-    },
-    "is-obj": {
-      "version": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-subset": {
-      "version": "http://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-      "dev": true
-    },
-    "is-text-path": {
-      "version": "http://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-      "dev": true,
-      "requires": {
-        "text-extensions": "http://registry.npmjs.org/text-extensions/-/text-extensions-1.4.0.tgz"
-      }
-    },
-    "is-utf8": {
-      "version": "http://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "isarray": {
       "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isexe": {
-      "version": "http://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-    },
-    "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "jsonparse": {
-      "version": "http://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
-      "integrity": "sha1-hfwkWx2SWazGlBlguQWt9k594Og=",
-      "dev": true
-    },
-    "kind-of": {
-      "version": "http://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-      }
-    },
-    "lazy-cache": {
-      "version": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
-    },
-    "lcid": {
-      "version": "http://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "http://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-      }
-    },
-    "load-json-file": {
-      "version": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "parse-json": "http://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-        "pify": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-        "strip-bom": "http://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-      }
-    },
-    "lodash": {
-      "version": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash._reinterpolate": {
-      "version": "http://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash.assign": {
-      "version": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
-    "lodash.template": {
-      "version": "http://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "http://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-        "lodash.templatesettings": "http://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "http://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "http://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-      }
-    },
-    "longest": {
-      "version": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "loud-rejection": {
-      "version": "http://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "http://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-      }
-    },
-    "map-obj": {
-      "version": "http://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
-    },
-    "meow": {
-      "version": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
-      "requires": {
-        "camelcase-keys": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-        "decamelize": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "loud-rejection": "http://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-        "map-obj": "http://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "normalize-package-data": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-        "read-pkg-up": "http://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "redent": "http://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-        "trim-newlines": "http://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-      }
-    },
-    "minimist": {
-      "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
-    },
-    "modify-values": {
-      "version": "http://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
-      "dev": true
-    },
-    "ms": {
+    "locate-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "normalize-package-data": {
-      "version": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz",
-        "is-builtin-module": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-        "semver": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "validate-npm-package-license": "http://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-      }
-    },
-    "null-check": {
-      "version": "http://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-      "dev": true
-    },
-    "number-is-nan": {
-      "version": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
-    "optimist": {
-      "version": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-        "wordwrap": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
       }
     },
-    "os-locale": {
-      "version": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+    "lodash": {
+      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "lcid": "http://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
-    "parse-github-repo-url": {
-      "version": "http://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
-      "integrity": "sha1-KGxT4smWLgZBZJ7jrJUI/KTdlZw=",
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
+    },
     "parse-json": {
-      "version": "http://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -1233,462 +819,1366 @@
       }
     },
     "path-exists": {
-      "version": "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
       }
     },
-    "path-is-absolute": {
-      "version": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
-    "path-type": {
-      "version": "http://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "pify": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
-    },
     "pify": {
-      "version": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
-      "version": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
-      "version": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
       }
     },
     "process-nextick-args": {
       "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
-    "q": {
-      "version": "http://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "read-pkg": {
-      "version": "http://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "load-json-file": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-        "normalize-package-data": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-        "path-type": "http://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+        "shebang-regex": "1.0.0"
       }
     },
-    "read-pkg-up": {
-      "version": "http://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-        "read-pkg": "http://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-      }
-    },
-    "readable-stream": {
-      "version": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-      "integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-      "requires": {
-        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-      }
-    },
-    "redent": {
-      "version": "http://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
-      "requires": {
-        "indent-string": "http://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-        "strip-indent": "http://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-      }
-    },
-    "repeat-string": {
-      "version": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "repeating": {
-      "version": "http://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-      }
-    },
-    "require-directory": {
-      "version": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
-    },
-    "right-align": {
-      "version": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-      }
-    },
-    "semver": {
-      "version": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
-    },
-    "source-map": {
-      "version": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "dev": true,
-      "requires": {
-        "amdefine": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-      }
     },
     "spdx-correct": {
-      "version": "http://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
       }
     },
     "spdx-expression-parse": {
-      "version": "http://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
       "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
       "dev": true
     },
     "spdx-license-ids": {
-      "version": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
-    "split": {
-      "version": "http://registry.npmjs.org/split/-/split-1.0.0.tgz",
-      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
-      "dev": true,
-      "requires": {
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-      }
-    },
-    "split2": {
-      "version": "http://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-      "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A=",
-      "dev": true,
-      "requires": {
-        "through2": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-      }
-    },
     "standard-version": {
-      "version": "http://registry.npmjs.org/standard-version/-/standard-version-4.0.0.tgz",
-      "integrity": "sha1-5XjO/UOrewKUS9dWlSUFLqwbl4c=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.2.0.tgz",
+      "integrity": "sha1-MBfoxc7SqS23UBeQJVw7qFFXN10=",
       "dev": true,
       "requires": {
-        "chalk": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "conventional-changelog": "http://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.3.tgz",
-        "conventional-recommended-bump": "http://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-0.3.0.tgz",
-        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-        "fs-access": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-        "semver": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "yargs": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz"
+        "chalk": "1.1.3",
+        "conventional-changelog": "1.1.7",
+        "conventional-recommended-bump": "1.0.3",
+        "figures": "1.7.0",
+        "fs-access": "1.0.1",
+        "semver": "5.4.1",
+        "yargs": "8.0.2"
       },
       "dependencies": {
-        "yargs": {
-          "version": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
           "dev": true,
           "requires": {
-            "camelcase": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-            "cliui": "http://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "decamelize": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "get-caller-file": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "os-locale": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "read-pkg-up": "http://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "require-directory": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "require-main-filename": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "set-blocking": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "string-width": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "which-module": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "y18n": "http://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "yargs-parser": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
           }
         },
-        "yargs-parser": {
-          "version": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+        "align-text": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
-            "camelcase": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
           }
-        }
-      }
-    },
-    "string-width": {
-      "version": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-        "is-fullwidth-code-point": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-        "strip-ansi": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      }
-    },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "strip-ansi": {
-      "version": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-      }
-    },
-    "strip-bom": {
-      "version": "http://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "http://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-      }
-    },
-    "strip-indent": {
-      "version": "http://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-      }
-    },
-    "supports-color": {
-      "version": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "text-extensions": {
-      "version": "http://registry.npmjs.org/text-extensions/-/text-extensions-1.4.0.tgz",
-      "integrity": "sha1-w4XS6Ah5/m75eJPhcJ2I2UU3Juk=",
-      "dev": true
-    },
-    "through": {
-      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "through2": {
-      "version": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      }
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-    },
-    "trim-newlines": {
-      "version": "http://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true
-    },
-    "trim-off-newlines": {
-      "version": "http://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-      "dev": true
-    },
-    "typedarray": {
-      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.8.20.tgz",
-      "integrity": "sha1-vocQD7wY3jh27WBunSS0VoMRzs8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "source-map": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-        "uglify-to-browserify": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-        "yargs": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-      },
-      "dependencies": {
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+          "dev": true
+        },
+        "array-ify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+          "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
         "camelcase": {
-          "version": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
-          "optional": true
+          "requires": {
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
+          }
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "cliui": {
-          "version": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-            "right-align": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-            "wordwrap": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "dev": true,
+              "optional": true
+            }
           }
         },
-        "source-map": {
-          "version": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "compare-func": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+          "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+          "dev": true,
+          "requires": {
+            "array-ify": "1.0.0",
+            "dot-prop": "3.0.0"
+          }
+        },
+        "concat-stream": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
+          }
+        },
+        "conventional-changelog": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.7.tgz",
+          "integrity": "sha1-kVGmKx2O2y2CcR2r9bfPcQQfgrE=",
+          "dev": true,
+          "requires": {
+            "conventional-changelog-angular": "1.5.2",
+            "conventional-changelog-atom": "0.1.2",
+            "conventional-changelog-codemirror": "0.2.1",
+            "conventional-changelog-core": "1.9.3",
+            "conventional-changelog-ember": "0.2.9",
+            "conventional-changelog-eslint": "0.2.1",
+            "conventional-changelog-express": "0.2.1",
+            "conventional-changelog-jquery": "0.1.0",
+            "conventional-changelog-jscs": "0.1.0",
+            "conventional-changelog-jshint": "0.2.1"
+          }
+        },
+        "conventional-changelog-angular": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.2.tgz",
+          "integrity": "sha1-Kzj2Zf6cWSCvGi+C9Uf0ur5t5Xw=",
+          "dev": true,
+          "requires": {
+            "compare-func": "1.3.2",
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-atom": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz",
+          "integrity": "sha1-Ella1SZ6aTfDTPkAKBscZRmKTGM=",
+          "dev": true,
+          "requires": {
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-codemirror": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz",
+          "integrity": "sha1-KZpPcUe681DmyBWPxUlUopHFzAk=",
+          "dev": true,
+          "requires": {
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-core": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.3.tgz",
+          "integrity": "sha1-KJn+d5OJoynw7EsnRsNt3vuY2i0=",
+          "dev": true,
+          "requires": {
+            "conventional-changelog-writer": "2.0.2",
+            "conventional-commits-parser": "2.0.1",
+            "dateformat": "1.0.12",
+            "get-pkg-repo": "1.4.0",
+            "git-raw-commits": "1.3.0",
+            "git-remote-origin-url": "2.0.0",
+            "git-semver-tags": "1.2.3",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "normalize-package-data": "2.4.0",
+            "q": "1.5.1",
+            "read-pkg": "1.1.0",
+            "read-pkg-up": "1.0.1",
+            "through2": "2.0.3"
+          }
+        },
+        "conventional-changelog-ember": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.9.tgz",
+          "integrity": "sha1-jsc8wFTjqwZGZ/sf61L+jvGxZDg=",
+          "dev": true,
+          "requires": {
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-eslint": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz",
+          "integrity": "sha1-LCoRvrIW+AZJunKDQYApO2h8BmI=",
+          "dev": true,
+          "requires": {
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-express": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz",
+          "integrity": "sha1-g42eHmyQmXA7FQucGaoteBdCvWw=",
+          "dev": true,
+          "requires": {
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-jquery": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
+          "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
+          "dev": true,
+          "requires": {
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-jscs": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
+          "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
+          "dev": true,
+          "requires": {
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-jshint": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz",
+          "integrity": "sha1-hhObs6yZiZ8rF36WF+CbN9mbzzo=",
+          "dev": true,
+          "requires": {
+            "compare-func": "1.3.2",
+            "q": "1.5.1"
+          }
+        },
+        "conventional-changelog-writer": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.2.tgz",
+          "integrity": "sha1-tYV97RsAHa+aeLnNQJJvRcE0lJs=",
+          "dev": true,
+          "requires": {
+            "compare-func": "1.3.2",
+            "conventional-commits-filter": "1.1.0",
+            "dateformat": "1.0.12",
+            "handlebars": "4.0.11",
+            "json-stringify-safe": "5.0.1",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "meow": "3.7.0",
+            "semver": "5.4.1",
+            "split": "1.0.1",
+            "through2": "2.0.3"
+          }
+        },
+        "conventional-commits-filter": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.0.tgz",
+          "integrity": "sha1-H8Ka8wte2rdvVOIpxBGwxmPQ+es=",
+          "dev": true,
+          "requires": {
+            "is-subset": "0.1.1",
+            "modify-values": "1.0.0"
+          }
+        },
+        "conventional-commits-parser": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.1.tgz",
+          "integrity": "sha1-HxXOa4RPfKQUlcgZDAgzwwuLFpM=",
+          "dev": true,
+          "requires": {
+            "JSONStream": "1.3.1",
+            "is-text-path": "1.0.1",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "meow": "3.7.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3",
+            "trim-off-newlines": "1.0.1"
+          }
+        },
+        "conventional-recommended-bump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.0.3.tgz",
+          "integrity": "sha1-RytpsbjwnFxO1A/iikHmPMBL1zY=",
+          "dev": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "conventional-commits-filter": "1.1.0",
+            "conventional-commits-parser": "2.0.1",
+            "git-raw-commits": "1.3.0",
+            "git-semver-tags": "1.2.3",
+            "meow": "3.7.0",
+            "object-assign": "4.1.1"
+          }
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+          "dev": true,
+          "requires": {
+            "array-find-index": "1.0.2"
+          }
+        },
+        "dargs": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+          "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "dateformat": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "dot-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+          "dev": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "fs-access": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+          "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+          "dev": true,
+          "requires": {
+            "null-check": "1.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "dev": true
+        },
+        "get-pkg-repo": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+          "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "meow": "3.7.0",
+            "normalize-package-data": "2.4.0",
+            "parse-github-repo-url": "1.4.1",
+            "through2": "2.0.3"
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        },
+        "git-raw-commits": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.0.tgz",
+          "integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
+          "dev": true,
+          "requires": {
+            "dargs": "4.1.0",
+            "lodash.template": "4.4.0",
+            "meow": "3.7.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3"
+          }
+        },
+        "git-remote-origin-url": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+          "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+          "dev": true,
+          "requires": {
+            "gitconfiglocal": "1.0.0",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+          }
+        },
+        "git-semver-tags": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.3.tgz",
+          "integrity": "sha1-GItFOIK/nXojr9Mbq6U32rc4jV0=",
+          "dev": true,
+          "requires": {
+            "meow": "3.7.0",
+            "semver": "5.4.1"
+          }
+        },
+        "gitconfiglocal": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+          "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+          "dev": true,
+          "requires": {
+            "ini": "1.3.5"
+          }
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+          "dev": true
+        },
+        "is-subset": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+          "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+          "dev": true
+        },
+        "is-text-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+          "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+          "dev": true,
+          "requires": {
+            "text-extensions": "1.7.0"
+          }
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "dev": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+          "dev": true
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0"
+          }
+        },
+        "longest": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "dev": true
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+          "dev": true,
+          "requires": {
+            "currently-unhandled": "0.4.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        },
+        "meow": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "modify-values": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
+          "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+          }
+        },
+        "null-check": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+          "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
+          "dev": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+              "dev": true
+            }
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "parse-github-repo-url": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+          "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
+        },
+        "q": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+          "dev": true,
+          "requires": {
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+          "dev": true,
+          "requires": {
+            "through": "2.3.8"
+          }
+        },
+        "split2": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+          "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+          "dev": true,
+          "requires": {
+            "through2": "2.0.3"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "text-extensions": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
+          "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+          "dev": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+          "dev": true
+        },
+        "trim-off-newlines": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+          "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+          "dev": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+              "dev": true,
+              "optional": true
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true,
+              "optional": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "dev": true,
+          "optional": true
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
         "window-size": {
-          "version": "http://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
-          "version": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
-          "optional": true
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
         },
         "yargs": {
-          "version": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
-          "optional": true,
           "requires": {
-            "camelcase": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-            "cliui": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-            "decamelize": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "window-size": "http://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "dev": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                "strip-bom": "3.0.0"
+              }
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+              "dev": true,
+              "requires": {
+                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+              }
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+              "dev": true,
+              "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+              "dev": true,
+              "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
+            }
           }
         }
       }
     },
-    "uglify-to-browserify": {
-      "version": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "util-deprecate": {
       "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "validate-npm-package-license": {
-      "version": "http://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "http://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-        "spdx-expression-parse": "http://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
       }
     },
-    "which": {
-      "version": "http://registry.npmjs.org/which/-/which-1.2.12.tgz",
-      "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true,
-      "requires": {
-        "isexe": "http://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-      }
-    },
-    "which-module": {
-      "version": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "window-size": {
-      "version": "http://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
-    },
-    "wrap-ansi": {
-      "version": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
-      "requires": {
-        "string-width": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "strip-ansi": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      }
-    },
-    "xtend": {
-      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "y18n": {
-      "version": "http://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
-    },
-    "yargs": {
-      "version": "http://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
-      "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
-      "dev": true,
-      "requires": {
-        "cliui": "http://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-        "decamelize": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "get-caller-file": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-        "lodash.assign": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-        "os-locale": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-        "read-pkg-up": "http://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "require-directory": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-        "require-main-filename": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-        "set-blocking": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-        "string-width": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "which-module": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-        "window-size": "http://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-        "y18n": "http://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-        "yargs-parser": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz"
-      }
-    },
-    "yargs-parser": {
-      "version": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
-      "integrity": "sha1-UIE1XRnZ0MjF2BrakIy05tGGZk8=",
-      "dev": true,
-      "requires": {
-        "camelcase": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-        "lodash.assign": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "eslint": "^4.9.0"
   },
   "dependencies": {
-    "babel-eslint": "^8.0.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsdoc": "^3.0.0"
   },


### PR DESCRIPTION
BREAKING CHANGE: You need to add babel-eslint as project dependencies in project where the peerigon/flowtype rules are used. You don't need to change anything if you're using other rules.