### PR TITLE
feat: Disable "class-methods-use-this"

### DIFF
--- a/base.js
+++ b/base.js
@@ -84,7 +84,7 @@ module.exports = {
         // Handled by babel/camelcase
         "camelcase": "off", // http://eslint.org/docs/rules/camelcase
         "capitalized-comments": ["off"], // http://eslint.org/docs/rules/capitalized-comments
-        "class-methods-use-this": ["warn"], // http://eslint.org/docs/rules/class-methods-use-this
+        "class-methods-use-this": ["off"], // http://eslint.org/docs/rules/class-methods-use-this
         "comma-dangle": [
             "warn",
             {


### PR DESCRIPTION
There are cases where this rule interferes with the intended goal.  
Usually classes are used on purpose to share state between functions. However, there are some cases in which functions rightly do not access a state from the class. So in some cases this rule hinders more than it helps.
In short: You can't really forget to access the state when you need it, but if you don't need it, this shouldn't be "criticized".

* Dependency injected parameters (instead of class state)
* Calculating a return result by only calling an imported utility function
* returning a hardcoded value

e.g.
```ts
	@Get("/status")
	getStatus(): string {
		return "OK";
	}
```

