### PR TITLE
feat: Add prefer array shorthand style option

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,32 @@ As an escape hatch, this is still allowed:
 const Hello = <div>{'test'}</div>;
 ```
 
+### [`peerigon/styles/prefer-array-shorthand`](styles/prefer-array-shorthand.js)
+
+**Important: Use it in combination with [`peerigon/typescript`](typescript.js).**
+
+Enforces typescript arrays to use the shorthand array-style instead of the generic style.
+
+```js
+    "extends": [
+        "peerigon",
+        "peerigon/typescript",
+        "peerigon/styles/prefer-array-shorthand"
+    ],
+```
+
+It enforces this:
+
+```ts
+const foo: string[] = [];
+```
+
+instead of
+
+```ts
+const foo: Array<string> = [];
+```
+
 ## Prettier
 
 There is a [Prettier](https://prettier.io/) config in this repository that corresponds to our linting rules as much as possible. Add a `.prettierrc` file to your repository with the following content:

--- a/styles/prefer-array-shorthand.js
+++ b/styles/prefer-array-shorthand.js
@@ -1,0 +1,16 @@
+/* eslint sort-keys: ["error", "asc"], quote-props: ["error", "consistent"] */
+/* eslint-disable sort-keys */
+
+module.exports = {
+    plugins: [
+        "@typescript-eslint"
+    ],
+    rules: {
+        "@typescript-eslint/array-type": [
+            "warn",
+            {
+                default: 'array',
+            }
+        ]
+    }
+};


### PR DESCRIPTION
Adds a new `peerigon/styles/prefer-array-shorthand` style which sets the default typescript array style format from the default `Array<xyz>` to `xyz[]`.
Since there is no definitive correct way teams/projects have the option to choose what they prefer.