### PR TITLE
fix: Disable "no-anonymous-default-exports" rule in tests

### DIFF
--- a/glob-patterns.js
+++ b/glob-patterns.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     tests: [
-        "**/*.{test,spec}.*",
+        "**/*.{test,spec,stories}.*",
         "**/test{s,}/**",
     ],
     tooling: [

--- a/tests.js
+++ b/tests.js
@@ -37,5 +37,7 @@ module.exports = {
             // Allow Jest inline snapshots
             allowTemplateLiterals: true,
         }],
+        // Storybook stories export a default config object which gets used by their pipeline
+        "import/no-anonymous-default-export": "off"
     }
 };


### PR DESCRIPTION
This extends the test glob pattern to include storybook stories. So `Component.stories.tsx` files are treated like tests and get more relaxed rules applied.
Besides that, the rule `no-anonymous-default-exports` gets disabled because `.stories.tsx` files usually default export an anonymous object with the configuration of the story. 
Since this configuration object doesn't get used somewhere else in the application just by the storybook pipeline a meaningful name for the object isn't necessary.

So this is allowed with this change: 
```ts
export default {
	title: "Button",
	component: Button,
	decorators: [withKnobs],
};
```