### PR TITLE
feat: Disable "no-warning-comments"

### DIFF
--- a/base.js
+++ b/base.js
@@ -460,12 +460,12 @@ module.exports = {
         "no-var": "warn", // http://eslint.org/docs/rules/no-var
         "no-void": "off", // http://eslint.org/docs/rules/no-void
         "no-warning-comments": [
-            "warn",
+            "off",
             {
                 location: "anywhere",
                 terms: ["todo", "fixme", "quickfix"],
             },
-        ],
+        ], // http://eslint.org/docs/rules/no-warning-comments
         "no-whitespace-before-property": "warn", // http://eslint.org/docs/rules/no-whitespace-before-property
         "no-with": "warn", // http://eslint.org/docs/rules/no-with
         // Non-block statements are disallowed anyway


### PR DESCRIPTION
Todo/Fixme/Quickfix comments are not bad per se.
If teams want to use them this shouldn't be prevented.
There is also tooling support in editors which can filter/search these comment. Combined with such tooling this can be a good way to annotate code parts, especially during active development.
So this pr removes this rule to allow the usage.