### PR TITLE
feat: Remove special handling for Prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Recommended configuration in your `package.json`:
 
 There are presets for the most common setups:
 
-### Prettier + TypeScript
+### TypeScript
 
 ```
 npm i eslint eslint-config-peerigon --save-dev
@@ -52,7 +52,7 @@ npm i eslint eslint-config-peerigon --save-dev
 ```js
 {
     "extends": [
-        "peerigon/presets/prettier-typescript.js"
+        "peerigon/presets/typescript.js"
     ],
     "env": {
         "node": true
@@ -61,7 +61,7 @@ npm i eslint eslint-config-peerigon --save-dev
 }
 ```
 
-### Prettier + TypeScript + React
+### TypeScript + React
 
 ```
 npm i eslint eslint-config-peerigon eslint-plugin-react eslint-plugin-jsx-a11y eslint-plugin-react-hooks --save-dev
@@ -70,7 +70,7 @@ npm i eslint eslint-config-peerigon eslint-plugin-react eslint-plugin-jsx-a11y e
 ```js
 {
     "extends": [
-        "peerigon/presets/prettier-typescript-react.js"
+        "peerigon/presets/typescript-react.js"
     ],
     "env": {
         "node": true,
@@ -80,7 +80,7 @@ npm i eslint eslint-config-peerigon eslint-plugin-react eslint-plugin-jsx-a11y e
 }
 ```
 
-### Prettier + TypeScript + Node
+### TypeScript + Node
 
 ```
 npm i eslint eslint-config-peerigon eslint-plugin-node --save-dev
@@ -89,20 +89,9 @@ npm i eslint eslint-config-peerigon eslint-plugin-node --save-dev
 ```js
 {
     "extends": [
-        "peerigon/presets/prettier-typescript-node.js"
+        "peerigon/presets/typescript-node.js"
     ],
     "root": true
-}
-```
-
-Your `package.json`:
-
-```json
-{
-    "type": "module",
-    "engines": {
-        "node": ">=14.0.0"
-    }
 }
 ```
 
@@ -110,7 +99,7 @@ Your `package.json`:
 
 ### Atomic changes
 
-Our formatting rules have been chosen carefully so that a change of a file is as atomic as possible. This makes it easier to review pull requests because there are no meaningless changes anymore.
+Our linting rules have been chosen carefully so that a change of a file is as atomic as possible. This makes it easier to review pull requests because there are no meaningless changes anymore.
 
 **Example:** I want to change a variable from `let` to `const`.
 
@@ -136,9 +125,7 @@ This is also the reason why we prefer [dangling commas](https://eslint.org/docs/
 
 ### Consistent formatting
 
-For the purpose of atomic changes, our rules are intentionally strict about formatting which are usually autofixable. You should use an editor configuration where you can apply these autofixes on demand (for instance when saving the file).
-
-We recommend combining these linting rules with [Prettier](https://prettier.io/) (see [below](#prettier)). There's also a [recommended configuration for VSCode](#vscode).
+We recommend combining these linting rules with [Prettier](https://prettier.io/). There's also a [recommended configuration for VSCode](#vscode).
 
 ### Code smells as a warning
 
@@ -181,27 +168,6 @@ If you don't agree with a rule, please do not just disable the rule. Often there
 ### Different styles
 
 We acknowledge that there are certain rules where there are no actual pros and cons or where there is no clear winner. You just have to decide for one style and stick with it. We also know that some rules make sense in one project, but don't make sense in another project. That's why we also provide a list of [accepted custom styles](#styles) (see also [this discussion](https://github.com/peerigon/eslint-config-peerigon/issues/11)) which you can pick.
-
-### Prettier
-
-In order to avoid conflicts between Prettier and our rules, you should always add **prettier rules at the end of `extends`**. For example, in a TypeScript + React project you would use the following configuration:
-
-```js
-{
-    "extends": [
-        "peerigon",
-        "peerigon/typescript",
-        "peerigon/styles/prefer-arrow",
-        "peerigon/react",
-        // prettier must be at the end
-        "prettier",
-        "prettier/react"
-    ],
-    "root": true,
-};
-```
-
-This module already lists [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) as dependency which is why you don't have to install it manually.
 
 ### VSCode
 
@@ -285,8 +251,7 @@ Add an `.eslintrc.json` to the project's root folder:
 {
     "extends": [
         // Base rules for every project
-        "peerigon",
-        "prettier" // add this at the end of 'extends' if you're using Prettier
+        "peerigon"
     ],
     // Do not search for further eslint configs in upper directories
     "root": true,
@@ -310,8 +275,7 @@ npm i eslint-plugin-node --save-dev
 {
     "extends": [
         "peerigon",
-        "peerigon/node",
-        "prettier" // add this if you're using Prettier
+        "peerigon/node"
     ],
     // Setting env.node = true is not necessary, this is already done by peerigon/node
     "root": true
@@ -344,9 +308,7 @@ These rules are also applicable in other JSX environments, like [Preact](https:/
 {
     "extends": [
         "peerigon",
-        "peerigon/react",
-        "prettier", // add this and...
-        "prettier/react" // ...this if you're using Prettier
+        "peerigon/react"
     ],
     "root": true
 }
@@ -368,8 +330,7 @@ Rules for [TypeScript](https://www.typescriptlang.org/).
         "peerigon/typescript",
         // Arrow functions are preferred with TypeScript
         // See https://github.com/peerigon/eslint-config-peerigon/issues/23#issuecomment-472614432
-        "peerigon/styles/prefer-arrow",
-        "prettier", // add this if you're using Prettier
+        "peerigon/styles/prefer-arrow"
     ],
     "root": true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
                 "@babel/eslint-plugin": "^7.22.10",
                 "@typescript-eslint/eslint-plugin": "^6.9.0",
                 "@typescript-eslint/parser": "^6.9.0",
-                "eslint-config-prettier": "^9.0.0",
                 "eslint-plugin-import": "^2.29.0",
                 "eslint-plugin-no-unsafe-regex": "^1.0.0",
                 "eslint-plugin-optimize-regex": "^1.2.1",
@@ -4560,17 +4559,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-config-prettier": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
-            "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
-            "bin": {
-                "eslint-config-prettier": "bin/cli.js"
-            },
-            "peerDependencies": {
-                "eslint": ">=7.0.0"
             }
         },
         "node_modules/eslint-find-rules": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
         "@babel/eslint-plugin": "^7.22.10",
         "@typescript-eslint/eslint-plugin": "^6.9.0",
         "@typescript-eslint/parser": "^6.9.0",
-        "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-no-unsafe-regex": "^1.0.0",
         "eslint-plugin-optimize-regex": "^1.2.1",

--- a/presets/typescript-node.js
+++ b/presets/typescript-node.js
@@ -7,8 +7,6 @@ module.exports = {
         "peerigon/typescript",
         "peerigon/styles/prefer-arrow",
         "peerigon/node",
-        // prettier must be at the end
-        "prettier",
     ],
     root: true,
 };

--- a/presets/typescript-react.js
+++ b/presets/typescript-react.js
@@ -6,8 +6,7 @@ module.exports = {
         "peerigon",
         "peerigon/typescript",
         "peerigon/styles/prefer-arrow",
-        // prettier must be at the end
-        "prettier",
+        "peerigon/react",
     ],
     root: true,
 };

--- a/presets/typescript.js
+++ b/presets/typescript.js
@@ -6,9 +6,6 @@ module.exports = {
         "peerigon",
         "peerigon/typescript",
         "peerigon/styles/prefer-arrow",
-        "peerigon/react",
-        // prettier must be at the end
-        "prettier",
     ],
     root: true,
 };

--- a/tests/react/.eslintrc.json
+++ b/tests/react/.eslintrc.json
@@ -1,12 +1,9 @@
 {
     "extends": [
-        // Should be the same as in "../../presets/prettier-typescript-react.js"
         "../../base.js",
         "../../typescript.js",
         "../../styles/prefer-arrow.js",
-        "../../react.js",
-        // prettier must be at the end
-        "prettier"
+        "../../react.js"
     ],
     "root": true
 }

--- a/tests/typescript/.eslintrc.js
+++ b/tests/typescript/.eslintrc.js
@@ -3,12 +3,10 @@ module.exports = {
         node: true,
     },
     extends: [
-        // Should be the same as in "../../presets/prettier-typescript.js"
+        // Should be the same as in "../../presets/typescript.js"
         "../../base.js",
         "../../typescript.js",
         "../../styles/prefer-arrow.js",
-        // prettier must be at the end
-        "prettier",
     ],
     root: true,
 };


### PR DESCRIPTION
Since we don't include formatting rules anymore, we also don't need to include special configs/rules for Prettier setups

BREAKING CHANGE: The `prettier-` prefix has been removed from all preset files: `peerigon/presets/prettier-typescript.js` becomes `peerigon/presets/typescript.js`, `peerigon/presets/prettier-typescript-react.js` becomes `peerigon/presets/typescript-react.js` and `peerigon/presets/prettier-typescript-node.js` becomes `peerigon/presets/typescript-node.js`